### PR TITLE
Predefine metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,15 @@
 
 This module is designed to abstract the way we store our metrics.
 
+## Mix tasks
+#### View defined metrics
+`mix list_metrics`
+
 ## Configure ExMetrics
+Example:
 ```
 config :ex_metrics,
-  dimensions: Keyword = [environment: "test", region: "eu-west-1", app_name: "some-app-name"],
-  send_metrics: Boolean = false | false
+  metrics: [:a_metric, "a_metric"],
+  send_metrics: Boolean,
+  raise_on_undefined_metrics: Boolean (recommended to be set to true on test & dev. defaults to false)
 ```

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,6 +2,10 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
+config :ex_metrics,
+  metrics: [:test_metric_name, :time_await]
+
+
 if File.regular?("config/#{Mix.env()}.exs") do
   import_config "#{Mix.env()}.exs"
 end

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,5 @@
 use Mix.Config
 
 config :ex_metrics,
-  send_metrics: false
+  send_metrics: false,
+  raise_on_undefined_metrics: true

--- a/lib/ex_metrics.ex
+++ b/lib/ex_metrics.ex
@@ -1,11 +1,13 @@
 defmodule ExMetrics do
+  alias ExMetrics.DefinedMetrics
 
   @stat_types [:timing, :increment, :decrement, :gauge, :set, :histogram]
 
   @stat_types
   |> Enum.each(fn stat_type ->
-    def unquote(stat_type)(key, value, opts \\ []) do
-      ExMetrics.Statsd.Worker.record({unquote(stat_type), [key, value, opts]})
+    def unquote(stat_type)(metric, value, opts \\ []) do
+      DefinedMetrics.raise_if_undefined_metric!(metric)
+      ExMetrics.Statsd.Worker.record({unquote(stat_type), [metric, value, opts]})
     end
   end)
 

--- a/lib/ex_metrics/defined_metrics.ex
+++ b/lib/ex_metrics/defined_metrics.ex
@@ -1,0 +1,45 @@
+defmodule ExMetrics.DefinedMetrics do
+
+  def defined?(metric) do
+    metric in defined_metrics()
+  end
+
+  def defined_metrics do
+    client_defined_metrics() ++ default_metrics()
+  end
+
+  def default_metrics do
+    response_code_metrics() ++ timing_metrics()
+  end
+
+  defp timing_metrics do
+    [:"timings.page"]
+  end
+
+  defp response_code_metrics do
+    [200, 202, 301, 302, 404, 408, 500, 501, 502]
+    |> Enum.map(fn status_code -> :"responses.#{status_code}" end)
+  end
+
+  def raise_if_undefined_metric!(metric) do
+    if raise_on_undefined_metrics?() and not defined?(metric) do
+      raise_undefined_metric!(metric)
+    end
+  end
+
+  defp client_defined_metrics do
+    Application.get_env(:ex_metrics, :metrics, [])
+  end
+
+  defp raise_on_undefined_metrics? do
+    Application.get_env(:ex_metrics, :raise_on_undefined_metrics, false)
+  end
+
+  defp raise_undefined_metric!(metric) do
+    raise """
+    Metric '#{metric}' is not defined in your config.
+    Define it like this:
+    config :ex_metrics, metrics: [:#{metric}]
+    """
+  end
+end

--- a/lib/mix/tasks/list_metrics.ex
+++ b/lib/mix/tasks/list_metrics.ex
@@ -1,0 +1,8 @@
+defmodule Mix.Tasks.ListMetrics do
+  use Mix.Task
+
+  def run(_) do
+    ExMetrics.DefinedMetrics.defined_metrics()
+    |> Enum.each(&IO.puts/1)
+  end
+end

--- a/test/defined_metrics_test.exs
+++ b/test/defined_metrics_test.exs
@@ -1,0 +1,26 @@
+defmodule Test.ExMetrics.DefinedMetrics do
+  use ExUnit.Case
+  alias ExMetrics.DefinedMetrics
+
+  setup do
+    Application.put_env(:ex_metrics, :raise_on_undefined_metrics, true)
+  end
+
+  test "raises error" do
+    assert_raise(
+      RuntimeError,
+      "Metric 'undefined_metric_name' is not defined in your config.\nDefine it like this:\nconfig :ex_metrics, metrics: [:undefined_metric_name]\n",
+      fn -> DefinedMetrics.raise_if_undefined_metric!(:undefined_metric_name) end
+    )
+  end
+
+  describe "option raise_on_undefined_metrics = false" do
+    setup do
+      Application.put_env(:ex_metrics, :raise_on_undefined_metrics, false)
+    end
+
+    test "does not raise error" do
+      DefinedMetrics.raise_if_undefined_metric!(:undefined_metric_name)
+    end
+  end
+end

--- a/test/ex_metrics_test.exs
+++ b/test/ex_metrics_test.exs
@@ -10,55 +10,56 @@ defmodule Test.ExMetrics do
 
   @expected_options []
   @expected_options_with_sample_rate Keyword.merge([sample_rate: 0.5], @expected_options)
-  def timing_mock("time-await", timing, @expected_options) when timing > 200 and timing < 205, do: :ok
+  def timing_mock(:time_await, timing, @expected_options) when timing > 200 and timing < 205,
+    do: :ok
 
   test "can record timings" do
     ExMetrics.Statsd.StatixConnectionMock
-    |> expect(:timing, fn "test-metric-name", 10, @expected_options -> :ok end)
+    |> expect(:timing, fn :test_metric_name, 10, @expected_options -> :ok end)
 
-    assert :ok == ExMetrics.timing("test-metric-name", 10)
+    assert :ok == ExMetrics.timing(:test_metric_name, 10)
   end
 
   test "can specify statix options" do
     ExMetrics.Statsd.StatixConnectionMock
-    |> expect(:increment, fn "test-metric-name", 5, @expected_options_with_sample_rate -> :ok end)
+    |> expect(:increment, fn :test_metric_name, 5, @expected_options_with_sample_rate -> :ok end)
 
-    assert :ok == ExMetrics.increment("test-metric-name", 5, sample_rate: 0.5)
+    assert :ok == ExMetrics.increment(:test_metric_name, 5, sample_rate: 0.5)
   end
 
   test "can increment metrics" do
     ExMetrics.Statsd.StatixConnectionMock
-    |> expect(:increment, fn "test-metric-name", 5, @expected_options -> :ok end)
+    |> expect(:increment, fn :test_metric_name, 5, @expected_options -> :ok end)
 
-    assert :ok == ExMetrics.increment("test-metric-name", 5)
+    assert :ok == ExMetrics.increment(:test_metric_name, 5)
   end
 
   test "can decrement metrics" do
     ExMetrics.Statsd.StatixConnectionMock
-    |> expect(:decrement, fn "test-metric-name", 5, @expected_options -> :ok end)
+    |> expect(:decrement, fn :test_metric_name, 5, @expected_options -> :ok end)
 
-    assert :ok == ExMetrics.decrement("test-metric-name", 5)
+    assert :ok == ExMetrics.decrement(:test_metric_name, 5)
   end
 
   test "can gauge metrics" do
     ExMetrics.Statsd.StatixConnectionMock
-    |> expect(:gauge, fn "test-metric-name", 5, @expected_options -> :ok end)
+    |> expect(:gauge, fn :test_metric_name, 5, @expected_options -> :ok end)
 
-    assert :ok == ExMetrics.gauge("test-metric-name", 5)
+    assert :ok == ExMetrics.gauge(:test_metric_name, 5)
   end
 
   test "can set metrics" do
     ExMetrics.Statsd.StatixConnectionMock
-    |> expect(:set, fn "test-metric-name", 5, @expected_options -> :ok end)
+    |> expect(:set, fn :test_metric_name, 5, @expected_options -> :ok end)
 
-    assert :ok == ExMetrics.set("test-metric-name", 5)
+    assert :ok == ExMetrics.set(:test_metric_name, 5)
   end
 
   test "can record histogram" do
     ExMetrics.Statsd.StatixConnectionMock
-    |> expect(:histogram, fn "test-metric-name", 5, @expected_options -> :ok end)
+    |> expect(:histogram, fn :test_metric_name, 5, @expected_options -> :ok end)
 
-    assert :ok == ExMetrics.histogram("test-metric-name", 5)
+    assert :ok == ExMetrics.histogram(:test_metric_name, 5)
   end
 
   test "can time snippets of code" do
@@ -66,7 +67,7 @@ defmodule Test.ExMetrics do
     |> expect(:timing, &timing_mock/3)
 
     result =
-      ExMetrics.timeframe "time-await" do
+      ExMetrics.timeframe :time_await do
         :timer.sleep(200)
         "pass on this result"
       end


### PR DESCRIPTION
### This PR
Allows metrics to be predefined in the application config. On test & dev MIX environments, any metric name used that has not been predefined will error. In production the metric will be sent through. This functionality is not enabled by default.

### Future progression:
This PR just outlines this functionality, and in the future, the config could look something more like this:
```
metrics: [
          [metric: :parse_error],
          [metric: :responses_5xx, chart: "1234", alarm_threshold: 200],
          [metric: :timing_4xx, chart: "5678"],
```

Where the `chart`, and `alarm_threshold` are optional, and are used to aid the mix tasks to generate documentation & define alarms and graphs.