### PR TITLE
RESFRAME-2701 - performance improvements - create list of allowed metrics as compile time

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -3,7 +3,7 @@
 use Mix.Config
 
 config :ex_metrics,
-  metrics: ["test_metric_name", "time_await", "benchmark.metric"]
+  metrics: ["test_metric_name", "time_await"]
 
 if File.regular?("config/#{Mix.env()}.exs") do
   import_config "#{Mix.env()}.exs"

--- a/config/config.exs
+++ b/config/config.exs
@@ -3,7 +3,7 @@
 use Mix.Config
 
 config :ex_metrics,
-  metrics: ["test_metric_name", "time_await"]
+  metrics: ["test_metric_name", "time_await", "benchmark.metric"]
 
 if File.regular?("config/#{Mix.env()}.exs") do
   import_config "#{Mix.env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,4 @@
+use Mix.Config
+
+config :ex_metrics,
+  send_metrics: false

--- a/lib/ex_metrics.ex
+++ b/lib/ex_metrics.ex
@@ -5,8 +5,7 @@ defmodule ExMetrics do
 
   @stat_types
   |> Enum.each(fn stat_type ->
-    def unquote(stat_type)(metric, value \\ 1, opts \\ [])
-        when is_binary(metric) and is_list(opts) and (is_integer(value) or is_float(value)) do
+    def unquote(stat_type)(metric, value \\ 1, opts \\ []) do
       DefinedMetrics.log_if_undefined_metric(metric)
 
       GenServer.cast(

--- a/lib/ex_metrics/defined_metrics.ex
+++ b/lib/ex_metrics/defined_metrics.ex
@@ -1,30 +1,23 @@
 defmodule ExMetrics.DefinedMetrics do
   require Logger
 
+  @status_codes Enum.to_list(200..599)
+
+  @response_code_metrics Enum.map(@status_codes, fn status_code ->
+                           "web.response.status.#{status_code}"
+                         end)
+
+  @timing_metrics ([:page] ++ @status_codes)
+                  |> Enum.map(fn status_code -> "web.response.timing.#{status_code}" end)
+
+  @default_metrics ["web.request.count"] ++ @response_code_metrics ++ @timing_metrics
+
   def defined?(metric) do
     metric in defined_metrics()
   end
 
   def defined_metrics do
-    client_defined_metrics() ++ default_metrics()
-  end
-
-  def default_metrics do
-    ["web.request.count"] ++ response_code_metrics() ++ timing_metrics()
-  end
-
-  defp timing_metrics do
-    ([:page] ++ status_codes())
-    |> Enum.map(fn status_code -> "web.response.timing.#{status_code}" end)
-  end
-
-  defp response_code_metrics do
-    status_codes()
-    |> Enum.map(fn status_code -> "web.response.status.#{status_code}" end)
-  end
-
-  defp status_codes do
-    Enum.to_list(200..599)
+    client_defined_metrics() ++ @default_metrics
   end
 
   def client_defined_metrics do

--- a/lib/mix/tasks/benchmark.ex
+++ b/lib/mix/tasks/benchmark.ex
@@ -10,10 +10,10 @@ defmodule Mix.Tasks.Benchmark do
     Benchee.run(
       %{
         "increment" => fn ->
-          ExMetrics.increment("benchmark.metric")
+          ExMetrics.increment("test_metric_name")
         end,
         "timeframe returns data" => fn ->
-          ExMetrics.timeframe "benchmark.metric" do
+          ExMetrics.timeframe "test_metric_name" do
             @data
           end
         end

--- a/lib/mix/tasks/benchmark.ex
+++ b/lib/mix/tasks/benchmark.ex
@@ -1,0 +1,25 @@
+defmodule Mix.Tasks.Benchmark do
+  use Mix.Task
+  use ExMetrics
+
+  size = 200 * 1024
+  @data :crypto.strong_rand_bytes(size) |> Base.encode64() |> binary_part(0, size)
+  def run(_) do
+    {:ok, _started} = Application.ensure_all_started(:ex_metrics)
+
+    Benchee.run(
+      %{
+        "increment" => fn ->
+          ExMetrics.increment("benchmark.metric")
+        end,
+        "timeframe returns data" => fn ->
+          ExMetrics.timeframe "benchmark.metric" do
+            @data
+          end
+        end
+      },
+      time: 10,
+      memory_time: 2
+    )
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,8 @@ defmodule ExMetrics.MixProject do
       {:plug_cowboy, "~> 2.0.1", only: :test},
       {:mox, "~> 0.5", only: :test},
       {:plug, ">= 1.7.0"},
-      {:statix, ">= 1.1.0"}
+      {:statix, ">= 1.1.0"},
+      {:benchee, ">= 1.0.1"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,9 @@
 %{
+  "benchee": {:hex, :benchee, "1.0.1", "66b211f9bfd84bd97e6d1beaddf8fc2312aaabe192f776e8931cb0c16f53a521", [:mix], [{:deep_merge, "~> 1.0", [hex: :deep_merge, repo: "hexpm", optional: false]}], "hexpm"},
   "certifi": {:hex, :certifi, "2.5.1", "867ce347f7c7d78563450a18a6a28a8090331e77fa02380b4a21962a65d36ee5", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
   "cowboy": {:hex, :cowboy, "2.6.1", "f2e06f757c337b3b311f9437e6e072b678fcd71545a7b2865bdaa154d078593f", [:rebar3], [{:cowlib, "~> 2.7.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.7.1", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "cowlib": {:hex, :cowlib, "2.7.0", "3ef16e77562f9855a2605900cedb15c1462d76fb1be6a32fc3ae91973ee543d2", [:rebar3], [], "hexpm"},
+  "deep_merge": {:hex, :deep_merge, "1.0.0", "b4aa1a0d1acac393bdf38b2291af38cb1d4a52806cf7a4906f718e1feb5ee961", [:mix], [], "hexpm"},
   "hackney": {:hex, :hackney, "1.15.1", "9f8f471c844b8ce395f7b6d8398139e26ddca9ebc171a8b91342ee15a19963f4", [:rebar3], [{:certifi, "2.5.1", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "6.0.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "~>1.1", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.4", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
   "httpoison": {:hex, :httpoison, "1.5.0", "71ae9f304bdf7f00e9cd1823f275c955bdfc68282bc5eb5c85c3a9ade865d68e", [:mix], [{:hackney, "~> 1.8", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "6.0.0", "689c46cbcdf3524c44d5f3dde8001f364cd7608a99556d8fbd8239a5798d4c10", [:rebar3], [{:unicode_util_compat, "0.4.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},

--- a/test/defined_metrics_test.exs
+++ b/test/defined_metrics_test.exs
@@ -9,13 +9,13 @@ defmodule Test.ExMetrics.DefinedMetrics do
 
   test "logs unspecified metric" do
     assert capture_log(fn ->
-      DefinedMetrics.log_if_undefined_metric(@metric)
-    end) =~ @log_msg
+             DefinedMetrics.log_if_undefined_metric(@metric)
+           end) =~ @log_msg
   end
 
   test "logs unspecified metric when using ExMetrics library interface" do
     assert capture_log(fn ->
-      ExMetrics.increment(@metric)
-    end) =~ @log_msg
+             ExMetrics.increment(@metric)
+           end) =~ @log_msg
   end
 end


### PR DESCRIPTION
Reduces metric increments from around 260.xx μs to 1.xx μs. This is because we no longer do the metric list building at runtime, but at compile time.