### PR TITLE
benchee as dev dep only

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule ExMetrics.MixProject do
       {:mox, "~> 0.5", only: :test},
       {:plug, ">= 1.7.0"},
       {:statix, ">= 1.1.0"},
-      {:benchee, ">= 1.0.1"}
+      {:benchee, ">= 1.0.1", only: :dev}
     ]
   end
 end


### PR DESCRIPTION
needed to avoid:
```
  > In mix.exs:
    {:benchee, "~> 1.0.1", [env: :prod, repo: "hexpm", hex: "benchee", only: :dev]}

  does not match the :only option calculated for

  > In deps/ex_metrics/mix.exs:
    {:benchee, ">= 1.0.1", [env: :prod, repo: "hexpm", hex: "benchee"]}
```

So applications also using benchee can restrict the dep to only the dev environment.