### PR TITLE
Enable pooling and concurrent data ports

### DIFF
--- a/lib/ex_metrics/config.ex
+++ b/lib/ex_metrics/config.ex
@@ -11,4 +11,8 @@ defmodule ExMetrics.Config do
   def statsd_port do
     Application.get_env(:ex_metrics, :statsd_port, 8125)
   end
+
+  def pool_size do
+    Application.get_env(:ex_metrics, :pool_size, 1)
+  end
 end

--- a/lib/ex_metrics/statsd/worker.ex
+++ b/lib/ex_metrics/statsd/worker.ex
@@ -29,5 +29,6 @@ defmodule ExMetrics.Statsd.Worker do
   defp set_up_statix do
     Application.put_env(:statix, :host, Config.statsd_host())
     Application.put_env(:statix, :port, Config.statsd_port())
+    Application.put_env(:statix, :pool_size, Config.pool_size())
   end
 end


### PR DESCRIPTION
ExMetrics currently uses a single port to send data to Statsd server. This might affect performance during high traffic load scenarios. This simple PR enables Statix pooling so that multiple concurrent ports may be configured.