### PR TITLE
Use monotonic time for timeframe

### DIFF
--- a/lib/ex_metrics.ex
+++ b/lib/ex_metrics.ex
@@ -13,11 +13,11 @@ defmodule ExMetrics do
 
   defmacro timeframe(key, do: yield) do
     quote do
-      before_time = System.monotonic_time(:microsecond)
+      before_time = System.monotonic_time(:millisecond)
       result = unquote(yield)
-      diff = (System.monotonic_time(:microsecond) - before_time) |> abs
+      diff = (System.monotonic_time(:millisecond) - before_time) |> abs
 
-      ExMetrics.timing(unquote(key), diff / 1_000)
+      ExMetrics.timing(unquote(key), diff)
       result
     end
   end

--- a/lib/ex_metrics.ex
+++ b/lib/ex_metrics.ex
@@ -13,10 +13,9 @@ defmodule ExMetrics do
 
   defmacro timeframe(key, do: yield) do
     quote do
-      before_time = :os.timestamp()
+      before_time = System.monotonic_time(:microsecond)
       result = unquote(yield)
-      after_time = :os.timestamp()
-      diff = :timer.now_diff(after_time, before_time)
+      diff = (System.monotonic_time(:microsecond) - before_time) |> abs
 
       ExMetrics.timing(unquote(key), diff / 1_000)
       result


### PR DESCRIPTION
Monotonic time should be used when measuring the time taken as system time is susceptible to time warps, leading to incorrect results. For example, it is possible for something which takes 1s to report that it took 1h due to timezone changes. `System.monotonic_time/0` is guaranteed to be a monotonically increasing time.

As the prior implementation made use of `:timer.now_diff` which returned the diff in microseconds, I have made `System.monotonic_time/0` return microseconds too (by default it appears to be nanoseconds). As the monotonic time can be reported as a negative value, I have piped the result into `abs`.